### PR TITLE
Fix: ALLEGRO_FILE* shouldn't be freed when using algif_load_animation_f

### DIFF
--- a/src/algif.c
+++ b/src/algif.c
@@ -57,7 +57,7 @@ void algif_render_frame(ALGIF_ANIMATION *gif, int frame, int xpos, int ypos) {
 }
 
 ALGIF_ANIMATION *algif_load_animation_f(ALLEGRO_FILE *file) {
-    ALGIF_ANIMATION *gif = algif_load_raw(file);
+    ALGIF_ANIMATION *gif = algif_load_raw(file, false);
 
     if (!gif)
         return gif;

--- a/src/algif.h
+++ b/src/algif.h
@@ -50,7 +50,7 @@ struct ALGIF_FRAME {
     ALLEGRO_BITMAP *rendered;
 };
 
-ALGIF_ANIMATION *algif_load_raw(ALLEGRO_FILE *file);
+ALGIF_ANIMATION *algif_load_raw(ALLEGRO_FILE *file, const bool freefp);
 ALGIF_ANIMATION *algif_load_animation_f(ALLEGRO_FILE *file);
 ALGIF_ANIMATION *algif_load_animation(char const *filename);
 void algif_render_frame(ALGIF_ANIMATION *gif, int frame, int xpos, int ypos);

--- a/src/gif.c
+++ b/src/gif.c
@@ -59,7 +59,7 @@ static void deinterlace (ALGIF_BITMAP *bmp)
     algif_destroy_bitmap (n);
 }
 
-ALGIF_ANIMATION *algif_load_raw(ALLEGRO_FILE *file) {
+ALGIF_ANIMATION *algif_load_raw(ALLEGRO_FILE *file, const bool freefp) {
     if (!file)
         return NULL;
 
@@ -217,13 +217,14 @@ ALGIF_ANIMATION *algif_load_raw(ALLEGRO_FILE *file) {
                 break;
             case 0x3b:
                 /* GIF Trailer. */
-                al_fclose (file);
+                if (freefp)
+                    al_fclose (file);
                 return gif;
         }
     }
     while (true);
   error:
-    if (file)
+    if (file && freefp)
         al_fclose (file);
     if (gif)
         algif_destroy_animation (gif);


### PR DESCRIPTION
I had an issue using this because I thought ALLEGRO_FILE* would be available later (as other al_..._f do), so probably this should be the way this works. I added a bool argument there because what if someone wants that to free the thing? I don't know.